### PR TITLE
feat: GET /api/reports 日報一覧取得エンドポイントを実装 (#7)

### DIFF
--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,0 +1,94 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { requireAuth, errorResponse, validationError } from "@/lib/api-helpers"
+import { prisma } from "@/lib/prisma"
+
+export async function GET(req: NextRequest): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth(req)
+    if (authResult instanceof NextResponse) {
+      return authResult
+    }
+    const user = authResult as NonNullable<SessionData["user"]>
+
+    const { searchParams } = req.nextUrl
+    const from = searchParams.get("from")
+    const to = searchParams.get("to")
+    const userIdParam = searchParams.get("user_id")
+
+    // from > to バリデーション
+    if (from && to && from > to) {
+      return validationError([
+        {
+          field: "from",
+          message: "開始日は終了日以前の日付を入力してください",
+        },
+      ])
+    }
+
+    // 日付フィルタ条件
+    const dateFilter: { gte?: Date; lte?: Date } = {}
+    if (from) {
+      dateFilter.gte = new Date(from)
+    }
+    if (to) {
+      const toDate = new Date(to)
+      toDate.setHours(23, 59, 59, 999)
+      dateFilter.lte = toDate
+    }
+
+    // ロール別 where 条件
+    const where: {
+      reportDate?: { gte?: Date; lte?: Date }
+      userId?: bigint
+    } = {}
+
+    if (Object.keys(dateFilter).length > 0) {
+      where.reportDate = dateFilter
+    }
+
+    if (user.role === "salesperson") {
+      // 営業担当者: 自分の日報のみ（user_id は無視）
+      where.userId = BigInt(user.id)
+    } else if (user.role === "manager" && userIdParam) {
+      // 上長: user_id フィルタが指定されていれば適用
+      const parsedUserId = parseInt(userIdParam, 10)
+      if (!isNaN(parsedUserId)) {
+        where.userId = BigInt(parsedUserId)
+      }
+    }
+
+    const reports = await prisma.dailyReport.findMany({
+      where,
+      orderBy: { reportDate: "desc" },
+      select: {
+        id: true,
+        reportDate: true,
+        problem: true,
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+        _count: {
+          select: { comments: true },
+        },
+      },
+    })
+
+    const responseReports = reports.map((report) => ({
+      id: Number(report.id),
+      report_date: report.reportDate.toISOString().split("T")[0],
+      user: {
+        id: Number(report.user.id),
+        name: report.user.name,
+      },
+      problem: report.problem,
+      comments_count: report._count.comments,
+    }))
+
+    return NextResponse.json({ reports: responseReports }, { status: 200 })
+  } catch {
+    return errorResponse("サーバーエラーが発生しました", 500)
+  }
+}


### PR DESCRIPTION
## Summary

- `src/app/api/reports/route.ts` に `GET /api/reports` ハンドラーを実装
- 営業担当者は自分の日報のみ返す（`user_id` クエリは無視）
- 上長は全員分を返す（`user_id` フィルタ有効）
- `from` / `to` クエリによる日付範囲フィルタ（`from > to` で 400）
- `report_date` 降順ソート固定

## Test plan

- [ ] API-4-1: 営業担当者は自分の日報のみ取得できる
- [ ] API-4-2: 上長は全員分の日報を取得できる
- [ ] API-4-3: `from` 指定で絞り込みが効く
- [ ] API-4-4: `to` 指定で絞り込みが効く
- [ ] API-4-5: `from` と `to` 両方指定で絞り込みが効く
- [ ] API-4-6: `from > to` → 400
- [ ] API-4-7: 上長が `user_id` フィルタを使うと特定担当者のみ返る
- [ ] API-4-8: 営業担当者が `user_id` を指定しても自分の日報のみ返る
- [ ] API-4-9: `report_date` 降順で返却される
- [ ] API-4-10: 未ログイン → 401

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)