### PR TITLE
feat: POST /api/reports 日報作成エンドポイントを実装 (#8)

### DIFF
--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -1,6 +1,39 @@
 import { type NextRequest, NextResponse } from "next/server"
-import { requireAuth, errorResponse, validationError } from "@/lib/api-helpers"
+import { requireAuth, requireRole, errorResponse, validationError } from "@/lib/api-helpers"
 import { prisma } from "@/lib/prisma"
+
+type VisitRecordInput = {
+  customer_id: unknown
+  content: unknown
+}
+
+type CreateReportBody = {
+  report_date?: unknown
+  visit_records?: unknown
+  problem?: unknown
+  plan?: unknown
+}
+
+/**
+ * JST (UTC+9) でのYYYY-MM-DD文字列を返す
+ */
+function getTodayJST(): string {
+  const now = new Date()
+  // UTC+9 に変換
+  const jstOffset = 9 * 60 * 60 * 1000
+  const jstDate = new Date(now.getTime() + jstOffset)
+  return jstDate.toISOString().split("T")[0]
+}
+
+/**
+ * DateオブジェクトをISO 8601形式（JST+09:00）の文字列に変換する
+ */
+function toJSTISOString(date: Date): string {
+  const jstOffset = 9 * 60 * 60 * 1000
+  const jstDate = new Date(date.getTime() + jstOffset)
+  const isoStr = jstDate.toISOString().replace("Z", "+09:00")
+  return isoStr
+}
 
 export async function GET(req: NextRequest): Promise<NextResponse> {
   try {
@@ -88,6 +121,233 @@ export async function GET(req: NextRequest): Promise<NextResponse> {
     }))
 
     return NextResponse.json({ reports: responseReports }, { status: 200 })
+  } catch {
+    return errorResponse("サーバーエラーが発生しました", 500)
+  }
+}
+
+export async function POST(req: NextRequest): Promise<NextResponse> {
+  try {
+    // 認証チェック
+    const authResult = await requireAuth(req)
+    if (authResult instanceof NextResponse) {
+      return authResult
+    }
+    const user = authResult as NonNullable<SessionData["user"]>
+
+    // 権限チェック: salesperson のみ
+    const roleError = requireRole(user, "salesperson")
+    if (roleError) {
+      return roleError
+    }
+
+    // リクエストボディのパース
+    let body: CreateReportBody
+    try {
+      body = (await req.json()) as CreateReportBody
+    } catch {
+      return errorResponse("リクエストボディが不正です", 400)
+    }
+
+    const { report_date, visit_records, problem, plan } = body
+
+    // バリデーション
+    const details: { field: string; message: string }[] = []
+
+    // report_date バリデーション
+    if (!report_date || typeof report_date !== "string" || report_date.trim() === "") {
+      details.push({ field: "report_date", message: "日付を入力してください" })
+    } else {
+      // YYYY-MM-DD形式チェック
+      const dateFormatRegex = /^\d{4}-\d{2}-\d{2}$/
+      if (!dateFormatRegex.test(report_date)) {
+        details.push({ field: "report_date", message: "日付はYYYY-MM-DD形式で入力してください" })
+      } else {
+        // 本日の日付のみ受け付ける（JST基準）
+        const todayJST = getTodayJST()
+        if (report_date !== todayJST) {
+          details.push({ field: "report_date", message: "日付は本日の日付のみ指定できます" })
+        }
+      }
+    }
+
+    // visit_records バリデーション
+    const visitRecordsRaw = visit_records
+    let parsedVisitRecords: VisitRecordInput[] = []
+    if (visitRecordsRaw !== undefined && visitRecordsRaw !== null) {
+      if (!Array.isArray(visitRecordsRaw)) {
+        details.push({ field: "visit_records", message: "訪問記録は配列で指定してください" })
+      } else {
+        parsedVisitRecords = visitRecordsRaw as VisitRecordInput[]
+        for (let i = 0; i < parsedVisitRecords.length; i++) {
+          const record = parsedVisitRecords[i]
+          // customer_id チェック
+          if (record.customer_id === undefined || record.customer_id === null) {
+            details.push({
+              field: `visit_records[${i}].customer_id`,
+              message: "顧客を選択してください",
+            })
+          } else if (
+            typeof record.customer_id !== "number" ||
+            !Number.isInteger(record.customer_id)
+          ) {
+            details.push({
+              field: `visit_records[${i}].customer_id`,
+              message: "顧客IDが不正です",
+            })
+          }
+          // content チェック
+          if (record.content === undefined || record.content === null || record.content === "") {
+            details.push({
+              field: `visit_records[${i}].content`,
+              message: "訪問内容を入力してください",
+            })
+          } else if (typeof record.content !== "string") {
+            details.push({
+              field: `visit_records[${i}].content`,
+              message: "訪問内容が不正です",
+            })
+          } else if (record.content.length > 1000) {
+            details.push({
+              field: `visit_records[${i}].content`,
+              message: "訪問内容は1000文字以内で入力してください",
+            })
+          }
+        }
+      }
+    }
+
+    // problem バリデーション
+    if (problem !== undefined && problem !== null) {
+      if (typeof problem !== "string") {
+        details.push({ field: "problem", message: "Problemが不正です" })
+      } else if (problem.length > 2000) {
+        details.push({ field: "problem", message: "Problemは2000文字以内で入力してください" })
+      }
+    }
+
+    // plan バリデーション
+    if (plan !== undefined && plan !== null) {
+      if (typeof plan !== "string") {
+        details.push({ field: "plan", message: "Planが不正です" })
+      } else if (plan.length > 2000) {
+        details.push({ field: "plan", message: "Planは2000文字以内で入力してください" })
+      }
+    }
+
+    // バリデーションエラーがあれば400を返す
+    if (details.length > 0) {
+      return validationError(details)
+    }
+
+    // customer_id の存在確認（バリデーション通過後）
+    const customerIdErrors: { field: string; message: string }[] = []
+    for (let i = 0; i < parsedVisitRecords.length; i++) {
+      const record = parsedVisitRecords[i]
+      const customerId = record.customer_id as number
+      const customerCount = await prisma.customer.count({
+        where: { id: BigInt(customerId) },
+      })
+      if (customerCount === 0) {
+        customerIdErrors.push({
+          field: `visit_records[${i}].customer_id`,
+          message: "指定された顧客が存在しません",
+        })
+      }
+    }
+    if (customerIdErrors.length > 0) {
+      return validationError(customerIdErrors)
+    }
+
+    // 当日の日報が既に存在するか確認（422）
+    const reportDateStr = report_date as string
+    // report_date を Date オブジェクトに変換（UTC 0時として扱う）
+    const reportDateObj = new Date(`${reportDateStr}T00:00:00.000Z`)
+    const existingReport = await prisma.dailyReport.findUnique({
+      where: {
+        userId_reportDate: {
+          userId: BigInt(user.id),
+          reportDate: reportDateObj,
+        },
+      },
+    })
+    if (existingReport) {
+      return errorResponse("本日の日報は既に作成されています", 422)
+    }
+
+    // 日報をトランザクションで作成
+    const createdReport = await prisma.$transaction(async (tx) => {
+      const report = await tx.dailyReport.create({
+        data: {
+          userId: BigInt(user.id),
+          reportDate: reportDateObj,
+          problem: typeof problem === "string" ? problem : null,
+          plan: typeof plan === "string" ? plan : null,
+          visitRecords: {
+            create: parsedVisitRecords.map((record) => ({
+              customerId: BigInt(record.customer_id as number),
+              content: record.content as string,
+            })),
+          },
+        },
+        include: {
+          user: {
+            select: { id: true, name: true },
+          },
+          visitRecords: {
+            include: {
+              customer: {
+                select: { id: true, name: true, companyName: true },
+              },
+            },
+            orderBy: { id: "asc" },
+          },
+          comments: {
+            include: {
+              commenter: {
+                select: { id: true, name: true },
+              },
+            },
+            orderBy: { createdAt: "asc" },
+          },
+        },
+      })
+      return report
+    })
+
+    // レスポンス整形
+    const responseReport = {
+      id: Number(createdReport.id),
+      report_date: createdReport.reportDate.toISOString().split("T")[0],
+      user: {
+        id: Number(createdReport.user.id),
+        name: createdReport.user.name,
+      },
+      visit_records: createdReport.visitRecords.map((vr) => ({
+        id: Number(vr.id),
+        customer: {
+          id: Number(vr.customer.id),
+          name: vr.customer.name,
+          company_name: vr.customer.companyName,
+        },
+        content: vr.content,
+      })),
+      problem: createdReport.problem,
+      plan: createdReport.plan,
+      comments: createdReport.comments.map((c) => ({
+        id: Number(c.id),
+        commenter: {
+          id: Number(c.commenter.id),
+          name: c.commenter.name,
+        },
+        body: c.body,
+        created_at: toJSTISOString(c.createdAt),
+      })),
+      created_at: toJSTISOString(createdReport.createdAt),
+      updated_at: toJSTISOString(createdReport.updatedAt),
+    }
+
+    return NextResponse.json({ report: responseReport }, { status: 201 })
   } catch {
     return errorResponse("サーバーエラーが発生しました", 500)
   }


### PR DESCRIPTION
## Summary

- `POST /api/reports` の実装（営業担当者のみ）
- JST基準で本日日付のみ受け付ける `report_date` バリデーション
- `visit_records` の `customer_id` DB存在確認
- 当日重複日報は 422、上長リクエストは 403

## Test plan

- [ ] API-5-1: 全項目あり → 201、作成された日報を返却
- [ ] API-5-2: 訪問記録なし → 201
- [ ] API-5-3: problem・plan 未入力 → 201
- [ ] API-5-4: 訪問記録を複数件登録できる
- [ ] API-5-5: 当日の日報が既に存在する → 422
- [ ] API-5-6: report_date が本日以外 → 400
- [ ] API-5-7: customer_id なし → 400
- [ ] API-5-8: 存在しない customer_id → 400
- [ ] API-5-9: 訪問内容が空文字 → 400
- [ ] API-5-10: 訪問内容が1001文字 → 400
- [ ] API-5-11: problem が2001文字 → 400
- [ ] API-5-12: plan が2001文字 → 400
- [ ] API-5-13: 上長によるリクエスト → 403
- [ ] API-5-14: 未ログイン → 401

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)