### PR TITLE
feat: GET /api/reports/:id 日報詳細取得エンドポイントを実装 (#9)

### DIFF
--- a/src/app/api/reports/[id]/route.ts
+++ b/src/app/api/reports/[id]/route.ts
@@ -1,0 +1,85 @@
+import { type NextRequest, NextResponse } from "next/server"
+import { requireAuth, errorResponse } from "@/lib/api-helpers"
+import { prisma } from "@/lib/prisma"
+
+type RouteParams = {
+  params: Promise<{ id: string }>
+}
+
+function formatJst(date: Date): string {
+  return date
+    .toLocaleString("sv-SE", { timeZone: "Asia/Tokyo" })
+    .replace(" ", "T")
+    .concat("+09:00")
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: RouteParams
+): Promise<NextResponse> {
+  try {
+    const authResult = await requireAuth(req)
+    if (authResult instanceof NextResponse) {
+      return authResult
+    }
+
+    const { id } = await params
+    const reportId = parseInt(id, 10)
+    if (isNaN(reportId)) {
+      return errorResponse("日報が見つかりません", 404)
+    }
+
+    const report = await prisma.dailyReport.findUnique({
+      where: { id: BigInt(reportId) },
+      include: {
+        user: true,
+        visitRecords: {
+          include: { customer: true },
+        },
+        comments: {
+          include: { commenter: true },
+          orderBy: { createdAt: "asc" },
+        },
+      },
+    })
+
+    if (!report) {
+      return errorResponse("日報が見つかりません", 404)
+    }
+
+    const responseReport = {
+      id: Number(report.id),
+      report_date: report.reportDate.toISOString().split("T")[0],
+      user: {
+        id: Number(report.user.id),
+        name: report.user.name,
+      },
+      visit_records: report.visitRecords.map((vr) => ({
+        id: Number(vr.id),
+        customer: {
+          id: Number(vr.customer.id),
+          name: vr.customer.name,
+          company_name: vr.customer.companyName,
+        },
+        content: vr.content,
+      })),
+      problem: report.problem,
+      plan: report.plan,
+      comments: report.comments.map((c) => ({
+        id: Number(c.id),
+        commenter: {
+          id: Number(c.commenter.id),
+          name: c.commenter.name,
+        },
+        body: c.body,
+        created_at: formatJst(c.createdAt),
+      })),
+      created_at: formatJst(report.createdAt),
+      updated_at: formatJst(report.updatedAt),
+    }
+
+    return NextResponse.json({ report: responseReport }, { status: 200 })
+  } catch {
+    return errorResponse("サーバーエラーが発生しました", 500)
+  }
+}


### PR DESCRIPTION
## Summary

- `GET /api/reports/:id` の実装（全ロール閲覧可能）
- `visit_records`・`comments`（投稿順）を含む詳細レスポンスを返す
- タイムスタンプは JST (+09:00) 形式、`report_date` は `YYYY-MM-DD` 形式

## Test plan

- [ ] API-6-1: 自分の日報を取得 → 200、visit_records・comments含む
- [ ] API-6-2: 他人の日報を取得 → 200（閲覧は全員可能）
- [ ] API-6-3: 上長が取得 → 200
- [ ] API-6-4: 存在しない ID → 404
- [ ] API-6-5: 未ログイン → 401
- [ ] API-6-6: コメントが投稿順（created_at 昇順）で返却される

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)